### PR TITLE
Added jQuery that makes all external links open in new tabs

### DIFF
--- a/site.js
+++ b/site.js
@@ -91,5 +91,10 @@ $(document).ready(function (){
         }
 	});
 
+    //external links open a new tab
+    $('a').filter(function() {
+        return this.hostname && (this.hostname !== location.hostname);
+    }).attr("target","_blank");
+
 });
 


### PR DESCRIPTION
I recently used the CU CS VM install website and I proposed to have all external links (links that navigate away from the current host) to open in new tabs, which allows the user to keep their place in the installation process. Previously, when a link was clicked, users were directed away from the installation guide.

``` jQuery
    $('a').filter(function() {
        return this.hostname && (this.hostname !== location.hostname);
    }).attr("target","_blank");
```

The code filters all `<a>` tags to links that have a hostname and that hostname is not the same as the current hostname and assigns them the attribute `target="_blank"`, which tells a browser to open a link in a new tab or new window (depending on user preferences).
