### PR TITLE
Exclude certain external file extensions from being labeled 'external'

### DIFF
--- a/site.js
+++ b/site.js
@@ -92,9 +92,13 @@ $(document).ready(function (){
 	});
 
     //external links open a new tab
-    $('a').filter(function() {
-        return this.hostname && (this.hostname !== location.hostname);
+    $("a").filter(function() {
+        // to ignore another file with the extension "file":
+        //      "a[href$='.torrent'], a[href$='.zip'], a[href$='.file']"
+        var isDownloadFile = $(this).is($("a[href$='.torrent'], a[href$='.zip']"));
+        return this.hostname && (this.hostname !== location.hostname) && !isDownloadFile;
     }).attr("target","_blank");
 
+    // $("a[href$='.torrent'], a[href$='.zip']").removeAttr("target");
 });
 


### PR DESCRIPTION
For readability, I added a variable `isDownloadFile` which is true if the currently selected `<a>`  ends with the string `.torrent` or `.zip` (determined by the `$=` part).

You can add additional file types by extending the list like I've done in the comment:

``` JavaScript
// to ignore another file with the extension "file":
//      "a[href$='.torrent'], a[href$='.zip'], a[href$='.file']"
```

In order to include instead of exclude types:

``` JavaScript
var isIncludedFile = $(this).is($("a[href$='.html'], a[href$='.php']"));
return this.hostname && (this.hostname !== location.hostname) && isIncludedFile;
```
